### PR TITLE
Use standard env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ Configuration is done completely via environment variables.
 | Variable | Description |
 | -- | -- |
 | `SENTRY_DSN` | **Required** DSN for a Sentry project. |
+| `SENTRY_ENVIRONMENT` | Environment for Sentry issues. If not set the namespace is used as environment. |
 | `NAMESPACE` | If set only monitor events within this Kubernetes namespace. If not set all namespaces are monitored (as far as permissions allowed) |
-| `ENVIRONMENT` | Environment for Sentry issues. If not set the namespace is used as environment. |
 
 ## Issue grouping
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 # k8s-sentry
 
-*k8s-sentry* is a simple tool to monitor a [Kubernetes](https://kubernetes.io) cluster and report all operational issues to [Sentry](http://sentry.io).
+_k8s-sentry_ is a simple tool to monitor a [Kubernetes](https://kubernetes.io) cluster and report all operational issues to [Sentry](http://sentry.io).
 
 ![Screenshot](docs/screenshot.png)
 
 There are two alternatives implementations:
 
-* [getsentry/sentry-kubernetes](https://github.com/getsentry/sentry-kubernetes): The official Sentry kubernetes reporter. This is not actively maintained and suffers from a [major memory leak](https://github.com/getsentry/sentry-kubernetes/issues/7).
-* [stevelacy/go-sentry-kubernetes](https://github.com/stevelacy/go-sentry-kubernetes): An alternative go implementation. This watches for Pod status changes only. This causes it to several event types (missing volumes, ingress errors, etc.).
+- [getsentry/sentry-kubernetes](https://github.com/getsentry/sentry-kubernetes): The official Sentry kubernetes reporter. This is not actively maintained and suffers from a [major memory leak](https://github.com/getsentry/sentry-kubernetes/issues/7).
+- [stevelacy/go-sentry-kubernetes](https://github.com/stevelacy/go-sentry-kubernetes): An alternative go implementation. This watches for Pod status changes only. This causes it to several event types (missing volumes, ingress errors, etc.).
 
-*k8s-sentry* watches for several things:
+_k8s-sentry_ watches for several things:
 
-* All warning and error events
-* Pod containers terminating with a non-zero exit code
-* Pods failing completely
+- All warning and error events
+- Pod containers terminating with a non-zero exit code
+- Pods failing completely
 
 ## Deployment
 
@@ -23,20 +23,20 @@ See [deploy](deploy/) for Kubernetes manifests and installation instructions.
 
 Configuration is done completely via environment variables.
 
-| Variable | Description |
-| -- | -- |
-| `SENTRY_DSN` | **Required** DSN for a Sentry project. |
-| `SENTRY_ENVIRONMENT` | Environment for Sentry issues. If not set the namespace is used as environment. |
-| `NAMESPACE` | If set only monitor events within this Kubernetes namespace. If not set all namespaces are monitored (as far as permissions allowed) |
+| Variable             | Description                                                                                                                          |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `SENTRY_DSN`         | **Required** DSN for a Sentry project.                                                                                               |
+| `SENTRY_ENVIRONMENT` | Environment for Sentry issues. If not set the namespace is used as environment.                                                      |
+| `NAMESPACE`          | If set only monitor events within this Kubernetes namespace. If not set all namespaces are monitored (as far as permissions allowed) |
 
 ## Issue grouping
 
-*k8s-sentry* tries to be smart about grouping issues. To handle that several strategies are used:
+_k8s-sentry_ tries to be smart about grouping issues. To handle that several strategies are used:
 
-* all issues use the event type, event reason and event message as part of the fingerprint
-* events related to controlled Pods (for example Pods created through a ReplicaSet (which is
+- all issues use the event type, event reason and event message as part of the fingerprint
+- events related to controlled Pods (for example Pods created through a ReplicaSet (which is
   automatically done if you use a StatefulSet or Deployment) are grouped by the ReplicateSet.
-* other events are grouped by the the involved object
+- other events are grouped by the the involved object
 
 ## Building
 

--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ import (
 )
 
 var configFlag = flag.String("kubeconfig", "", "Configuration file")
-var defaultEnvironment = os.Getenv("ENVIRONMENT")
+var defaultEnvironment = os.Getenv("SENTRY_ENVIRONMENT")
 
 func main() {
 	flag.Parse()
@@ -56,7 +56,7 @@ func main() {
 
 	app := application{
 		clientset:          clientset,
-		defaultEnvironment: os.Getenv("ENVIRONMENT"),
+		defaultEnvironment: os.Getenv("SENTRY_ENVIRONMENT"),
 		namespace:          os.Getenv("NAMESPACE"),
 	}
 


### PR DESCRIPTION
Sentry [official SDKs](https://docs.sentry.io/error-reporting/configuration/) make use of the `SENTRY_ENVIRONMENT`environment variable to configure the environment for Sentry events.

This PR simply renames the current `ENVIRONMENT` variable to `SENTRY_ENVIRONMENT`. It also makes small formatting changes to the README running it through [`prettier`](https://prettier.io/).