### PR TITLE
Modification of the pod observation

### DIFF
--- a/application.go
+++ b/application.go
@@ -220,8 +220,13 @@ func (app application) handleEventAdd(obj interface{}) {
 		sentryEvent.Environment = evt.InvolvedObject.Namespace
 	}
 
+	msg := evt.Message
+	if msg == "" {
+		msg = evt.Reason
+	}
+
 	sentryEvent.Logger = "kubernetes"
-	sentryEvent.Message = fmt.Sprintf("%s/%s: %s", evt.InvolvedObject.Kind, evt.InvolvedObject.Name, evt.Message)
+	sentryEvent.Message = fmt.Sprintf("%s/%s: %s", evt.InvolvedObject.Kind, evt.InvolvedObject.Name, msg)
 	sentryEvent.Level = getSentryLevel(evt)
 	sentryEvent.Timestamp = evt.ObjectMeta.CreationTimestamp.Time
 	sentryEvent.Fingerprint = []string{

--- a/application.go
+++ b/application.go
@@ -244,6 +244,9 @@ func (app application) handleEventAdd(obj interface{}) {
 	sentryEvent.Tags["reason"] = evt.Reason
 	sentryEvent.Tags["kind"] = evt.InvolvedObject.Kind
 	sentryEvent.Tags["type"] = evt.Type
+	if evt.ReportingController != "" {
+		sentryEvent.Tags["controller"] = evt.ReportingController
+	}
 	if evt.Action != "" {
 		sentryEvent.Extra["action"] = evt.Action
 	}

--- a/application.go
+++ b/application.go
@@ -232,7 +232,6 @@ func (app application) handleEventAdd(obj interface{}) {
 		evt.Source.Component,
 		evt.Type,
 		evt.Reason,
-		evt.Message,
 	}
 
 	sentryEvent.Tags["namespace"] = evt.InvolvedObject.Namespace

--- a/application_test.go
+++ b/application_test.go
@@ -12,22 +12,25 @@ func TestSkipEvent(t *testing.T) {
 	t.Parallel()
 
 	evt := &v1.Event{Type: v1.EventTypeNormal}
-	if !skipEvent(evt) {
+
+	skipLevels := []string{"normal"}
+
+	if !skipEvent(evt, skipLevels) {
 		t.Error("Normal events must be skipped")
 	}
 
 	evt.Type = v1.EventTypeWarning
-	if skipEvent(evt) {
+	if skipEvent(evt, skipLevels) {
 		t.Error("Warnings events must not be skipped")
 	}
 
 	evt.Type = "Error"
-	if skipEvent(evt) {
+	if skipEvent(evt, skipLevels) {
 		t.Error("Error events must not be skipped")
 	}
 
 	evt.Type = "Unknown"
-	if skipEvent(evt) {
+	if skipEvent(evt, skipLevels) {
 		t.Error("Unknown event types must not be skipped")
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/hashicorp/golang-lru v0.5.1
 	github.com/imdario/mergo v0.3.8 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6
 	golang.org/x/time v0.0.0-20190921001708-c4c64cad1fd0 // indirect
 	k8s.io/api v0.0.0-20191016110408-35e52d86657a
 	k8s.io/apimachinery v0.0.0-20191020214737-6c8691705fc5

--- a/go.sum
+++ b/go.sum
@@ -250,6 +250,7 @@ golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4Iltr
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6 h1:bjcUS9ztw9kFmmIxJInhon/0Is3p+EHBKNgquIzo1OI=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/go.sum
+++ b/go.sum
@@ -28,7 +28,6 @@ github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8Nz
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -78,7 +77,6 @@ github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/gomodule/redigo v1.7.1-0.20190724094224-574c33c3df38/go.mod h1:B4C85qUVwatsJoIUNIfCRsp7qO0iAmpGFZ4EELWSbC4=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
-github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
@@ -240,10 +238,8 @@ golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190327091125-710a502c58a2/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
-golang.org/x/net v0.0.0-20190503192946-f4e77d36d62c h1:uOCk1iQW6Vc18bnC13MfzScl+wdKBmM9Y9kU7Z83/lw=
 golang.org/x/net v0.0.0-20190503192946-f4e77d36d62c/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20190812203447-cdfb69ac37fc h1:gkKoSkUmnU6bpS/VhkuO27bzQeSA51uaEfbOW5dNb68=
 golang.org/x/net v0.0.0-20190812203447-cdfb69ac37fc/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297 h1:k7pJ2yAPLPgbskkFdhRCsA77k2fySZ1zf2zCjvQCiIM=
 golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -268,7 +264,6 @@ golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a h1:aYOabOQFp6Vj6W1F80affTUvO9UxmJRx8K0gsfABByQ=
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=

--- a/handler_default.go
+++ b/handler_default.go
@@ -18,6 +18,7 @@ package main
 import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"strings"
 )
 
 // DefaultEventHandler is the default handler for events.
@@ -31,7 +32,7 @@ func (h DefaultEventHandler) Fingerprint() []string {
 		h.Event.InvolvedObject.APIVersion,
 		h.Event.InvolvedObject.Kind,
 		h.Event.InvolvedObject.Namespace,
-		h.Event.InvolvedObject.Name,
+		mangleName(h.Event.InvolvedObject.Name),
 		h.Event.InvolvedObject.FieldPath,
 	}
 }
@@ -60,7 +61,7 @@ func fingerprintFromMeta(resource *metav1.ObjectMeta) []string {
 
 	name := resource.GenerateName
 	if name == "" {
-		name = resource.Name
+		name = mangleName(resource.Name)
 	}
 
 	// Otherwise we group based onthe object itself
@@ -68,4 +69,14 @@ func fingerprintFromMeta(resource *metav1.ObjectMeta) []string {
 		resource.Namespace,
 		name,
 	}
+}
+
+func mangleName(original string) string {
+	splits := strings.Split(original, "-")
+
+	if len(splits) < 3 {
+		return splits[0]
+	}
+
+	return strings.Join(splits[0:len(splits)-2], "-")
 }

--- a/handler_default.go
+++ b/handler_default.go
@@ -58,9 +58,14 @@ func fingerprintFromMeta(resource *metav1.ObjectMeta) []string {
 		}
 	}
 
+	name := resource.GenerateName
+	if name == "" {
+		name = resource.Name
+	}
+
 	// Otherwise we group based onthe object itself
 	return []string{
 		resource.Namespace,
-		string(resource.UID),
+		name,
 	}
 }

--- a/main.go
+++ b/main.go
@@ -62,9 +62,19 @@ func main() {
 		log.Fatalf("Error creating kubernetes client: %v", err)
 	}
 
+	skipEnv, isSet := os.LookupEnv("SKIP_EVENT_LEVELS")
+	var skipLevels []string
+
+	if isSet {
+		skipLevels = strings.Split(strings.ToLower(skipEnv), ",")
+	} else {
+		skipLevels = []string{strings.ToLower(v1.EventTypeNormal)}
+	}
+
 	app := application{
 		clientset:          clientset,
 		defaultEnvironment: os.Getenv("SENTRY_ENVIRONMENT"),
+		skipEventLevels:    skipLevels,
 	}
 
 	namespace := os.Getenv("NAMESPACE")

--- a/main.go
+++ b/main.go
@@ -62,19 +62,13 @@ func main() {
 		log.Fatalf("Error creating kubernetes client: %v", err)
 	}
 
-	skipEnv, isSet := os.LookupEnv("SKIP_EVENT_LEVELS")
-	var skipLevels []string
-
-	if isSet {
-		skipLevels = strings.Split(strings.ToLower(skipEnv), ",")
-	} else {
-		skipLevels = []string{strings.ToLower(v1.EventTypeNormal)}
-	}
+	skipEnv, _ := os.LookupEnv("SKIP_EVENT_LEVELS")
+	var skipLevels = parseSkipLevels(&skipEnv, v1.EventTypeNormal)
 
 	app := application{
-		clientset:          clientset,
-		defaultEnvironment: os.Getenv("SENTRY_ENVIRONMENT"),
-		skipEventLevels:    skipLevels,
+		clientset:             clientset,
+		defaultEnvironment:    os.Getenv("SENTRY_ENVIRONMENT"),
+		globalSkipEventLevels: skipLevels,
 	}
 
 	namespace := os.Getenv("NAMESPACE")

--- a/skip.go
+++ b/skip.go
@@ -2,10 +2,24 @@ package main
 
 import (
 	v1 "k8s.io/api/core/v1"
+	"log"
+	"strconv"
 	"strings"
 )
 
 const SkipLevelKey string = "secunet.sentry/skip-event-levels"
+const SkipReasonKey string = "secunet.sentry/skip-event-reasons"
+const SkipPodModificationEvent string = "secunet.sentry/ignore-pod-updates"
+
+const SkipEventReasonsEnv = "SKIP_EVENT_REASONS"
+const SkipEventLevelsEnv = "SKIP_EVENT_LEVELS"
+
+type SkipCriteria int
+
+const (
+	SKIP_BY_REASON SkipCriteria = iota
+	SKIP_BY_LEVEL  SkipCriteria = iota
+)
 
 func trim(mess []string) []string {
 
@@ -18,38 +32,122 @@ func trim(mess []string) []string {
 	return result
 }
 
-func parseSkipLevels(raw *string, fallback ...string) []string {
+func skipConfigLookupKey(criteriaType SkipCriteria, resourceType string, criteriaValue string) string {
+
+	var result strings.Builder
+
+	result.WriteString(strconv.Itoa(int(criteriaType)))
+	if len(resourceType) > 0 {
+		result.WriteString("-")
+		result.WriteString(resourceType)
+	}
+
+	result.WriteString("-")
+	result.WriteString(criteriaValue)
+
+	return strings.ToLower(result.String())
+}
+
+// Parses SkipConfig declarations from either environment variables or namespace annotation values. The supported
+// declaration format is: [involvedObjectType:]skipCriteria[,...].
+//
+// Some examples:
+//
+// Filter Pod, Service and PV events by their reason field:
+// Set env SkipEventReasonsEnv or the namespace annotation SkipReasonKey to e.g.:
+//   Pod:created,Service:AllocationFailed,PersistentVolume:PersistentVolumeDeleted
+//
+// Filter Pod, Service and PV events by their level:
+// Set env SkipEventLevelsEnv or the namespace annotation SkipLevelKey to e.g.:
+//   Pod:normal,Service:warning,PersistentVolume:normal
+//
+// Generally filter events with level normal, while selectively also filter warnings related to Pods or Services:
+// Set env SkipEventLevelsEnv or the namespace annotation SkipLevelKey to:
+//   normal,Pod:warning,Service:warning
+//
+// To find out which combinations of event level, object and reason currently exist, run:
+//   kubectl get events --all-namespaces -o custom-columns=OTYPE:.involvedObject.kind,LEVEL:.type,REASON:.reason,NAMESPACE:.metadata.namespace | sort | uniq
+//
+func parseSkipConfig(criteriaType SkipCriteria, raw *string, fallback ...string) []string {
+
+	var criteriaList []string
 
 	if raw == nil || len(strings.TrimSpace(*raw)) == 0 {
 
-		var dflt []string
-
-		for _, val := range fallback {
-			dflt = append(dflt, strings.ToLower(val))
-		}
-		return trim(dflt)
+		return fallback
 
 	} else {
-		return trim(strings.Split(strings.ToLower(*raw), ","))
+		criteriaList = trim(strings.Split(strings.ToLower(*raw), ","))
 	}
 
+	var result []string
+
+	for _, criteria := range criteriaList {
+
+		// expecting format of either "resourceType:criteria" or just "criteria"
+		// E.g.
+		// "Pod:created" means, if criteriaType is set to SKIP_BY_REASON:
+		// filter events whose involved object is a pod and the reason is "created"
+		// ":created" or "created" means, if criteriaType is set to SKIP_BY_REASON:
+		// filter ALL events of reason "created"
+		// ... the same applies for filtering by level, so:
+		// "ConfigMap:normal" means, if criteriaType is set to SKIP_BY_LEVEL:
+		// filter events whose involved object is a configmap and the event level is "normal"
+		typeAndCriteria := trim(strings.Split(strings.ToLower(criteria), ":"))
+
+		if len(typeAndCriteria) > 2 || len(typeAndCriteria) == 0 {
+			// declaration error, more than one ":" delimiter not supported
+			log.Printf("Illegal skip event config declaration, ignoring: %s\n", criteria)
+			continue
+		}
+
+		var resourceType string
+		var criteriaValue string
+
+		if len(typeAndCriteria) == 2 {
+			resourceType = strings.TrimSpace(strings.ToLower(typeAndCriteria[0]))
+			criteriaValue = strings.TrimSpace(strings.ToLower(typeAndCriteria[1]))
+		} else {
+			criteriaValue = strings.TrimSpace(strings.ToLower(strings.TrimSpace(typeAndCriteria[0])))
+		}
+
+		result = append(result, skipConfigLookupKey(criteriaType, resourceType, criteriaValue))
+	}
+
+	return result
 }
 
-func skipEvent(evt *v1.Event, nsSkipLevels map[string][]string, defaultSkipLevels []string) bool {
+func skipEvent(evt *v1.Event, nsSkipLevels map[string]map[string]struct{}) bool {
 
-	evtType := strings.ToLower(evt.Type)
-	evtNs := evt.Namespace
+	ns := evt.Namespace
+	reason := strings.ToLower(evt.Reason)
+	level := strings.ToLower(evt.Type)
+	oType := strings.ToLower(evt.InvolvedObject.Kind)
 
-	appliedSkipLevels, hasNsMapping := nsSkipLevels[evt.Namespace]
+	appliedSkipLevels, hasNsMapping := nsSkipLevels[ns]
 
-	if len(evtNs) == 0 || !hasNsMapping {
-		appliedSkipLevels = defaultSkipLevels
+	if len(ns) == 0 || !hasNsMapping {
+		appliedSkipLevels = nsSkipLevels[AnyNS]
 	}
 
-	for _, level := range appliedSkipLevels {
-		if level == evtType {
-			return true
-		}
+	_, hasOtypeSpecificReasonFilter := appliedSkipLevels[skipConfigLookupKey(SKIP_BY_REASON, oType, reason)]
+	if hasOtypeSpecificReasonFilter {
+		return true
+	}
+
+	_, hasOtypeAgnosticReasonFilter := appliedSkipLevels[skipConfigLookupKey(SKIP_BY_REASON, "", reason)]
+	if hasOtypeAgnosticReasonFilter {
+		return true
+	}
+
+	_, hasOtypeSpecificLevelFilter := appliedSkipLevels[skipConfigLookupKey(SKIP_BY_LEVEL, oType, level)]
+	if hasOtypeSpecificLevelFilter {
+		return true
+	}
+
+	_, hasOtypeAgnosticLevelFilter := appliedSkipLevels[skipConfigLookupKey(SKIP_BY_LEVEL, "", level)]
+	if hasOtypeAgnosticLevelFilter {
+		return true
 	}
 
 	return false

--- a/skip.go
+++ b/skip.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 )
 
-const SkipLevelKey string = "secunet.sentry/skip-event-levels"
-const SkipReasonKey string = "secunet.sentry/skip-event-reasons"
-const SkipPodModificationEvent string = "secunet.sentry/ignore-pod-updates"
+const SkipLevelKey string = "sentry/skip-event-levels"
+const SkipReasonKey string = "sentry/skip-event-reasons"
+const SkipPodModificationEvent string = "sentry/ignore-pod-updates"
 
 const SkipEventReasonsEnv = "SKIP_EVENT_REASONS"
 const SkipEventLevelsEnv = "SKIP_EVENT_LEVELS"

--- a/skip.go
+++ b/skip.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"strings"
+)
+
+const SkipLevelKey string = "secunet.sentry/skip-event-levels"
+
+func trim(mess []string) []string {
+
+	var result []string
+
+	for _, val := range mess {
+		result = append(result, strings.TrimSpace(val))
+	}
+
+	return result
+}
+
+func parseSkipLevels(raw *string, fallback ...string) []string {
+
+	if raw == nil || len(strings.TrimSpace(*raw)) == 0 {
+
+		var dflt []string
+
+		for _, val := range fallback {
+			dflt = append(dflt, strings.ToLower(val))
+		}
+		return trim(dflt)
+
+	} else {
+		return trim(strings.Split(strings.ToLower(*raw), ","))
+	}
+
+}
+
+func skipEvent(evt *v1.Event, nsSkipLevels map[string][]string, defaultSkipLevels []string) bool {
+
+	evtType := strings.ToLower(evt.Type)
+	evtNs := evt.Namespace
+
+	appliedSkipLevels, hasNsMapping := nsSkipLevels[evt.Namespace]
+
+	if len(evtNs) == 0 || !hasNsMapping {
+		appliedSkipLevels = defaultSkipLevels
+	}
+
+	for _, level := range appliedSkipLevels {
+		if level == evtType {
+			return true
+		}
+	}
+
+	return false
+}

--- a/test_pod.yaml
+++ b/test_pod.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test
+  namespace: default
+spec:
+  containers:
+    - command:
+        - "/bin/sh"
+      args:
+        - "-c"
+        - "sleep 3; exit 123"
+      image: alpine
+      imagePullPolicy: IfNotPresent
+      name: test
+  dnsPolicy: ClusterFirst
+  enableServiceLinks: true
+  hostNetwork: true
+  restartPolicy: Never
+  terminationGracePeriodSeconds: 1

--- a/test_pod.yaml
+++ b/test_pod.yaml
@@ -4,7 +4,7 @@ metadata:
   name: test
   namespace: default
   annotations:
-    secunet.sentry/ignore-pod-updates: "true"
+    sentry/ignore-pod-updates: "true"
 spec:
   containers:
     - command:

--- a/test_pod.yaml
+++ b/test_pod.yaml
@@ -3,6 +3,8 @@ kind: Pod
 metadata:
   name: test
   namespace: default
+  annotations:
+    secunet.sentry/ignore-pod-updates: "true"
 spec:
   containers:
     - command:


### PR DESCRIPTION
This is mainly a RFC as I'm aware that it changes the current behavior quite a bit - and I'm fine to keep it as a fork. Still I'm curious what others think of these changes:

* I've removed the PodFailed branch from the pod observation as in my case, when I hit this branch, the reason and message was always empty. So I got a lot of events "Pod/xyz: " without any further helpful metadata. If there is a pod-change I always search for terminated containers.
* Every failed container causes a sentry event now and not only the first one. They will be grouped by a common fingerprint though.
* I've used the generateName field instead of uuid for the fingerprint (if the object has no owner) as this is the stable for a lot of solutions working with some kind of pod template (in my case Jenkins and Gitlab-Runner). If the generateName is not provided it uses the name in a mangled form like the [sentry-kubernetes implementation did](https://github.com/getsentry/sentry-kubernetes/blob/master/sentry-kubernetes.py#L154-L159) to allow better grouping.
* I took the message out of the fingerprints as its often containing very specific information like the container ids preventing any grouping.